### PR TITLE
.kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,4 +1,4 @@
----
+--
 driver:
   name: vagrant
   

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,7 +60,7 @@ end
 
 remote_file '/var/www/latest.tar.gz' do
   source 'https://wordpress.org/latest.tar.gz'
-  checksum '1a4d9f05142701e72413609cc30029f66af0f3b29d4ff051e888f48026d20ac9'
+  checksum '7eae27ff70716dae2d2ba58280f2832fd70a208c9cdaf29ab36ac789c14d6977'
   notifies :run, 'bash[Extract]', :immediately
 end
 


### PR DESCRIPTION
edited so the converge would work in my environment, and then changed back to work with yours after a successful 'kitchen converge'.

recipies/default.db
updated with the new sha256 checksum for the newest version of wordpress downloaded in the recipe.